### PR TITLE
android namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 29
+    namespace "record.wilson.flutter.com.flutter_plugin_record"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
android namespace 跑步过去的问题

- [x] namespace

``` bash
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':flutter_plugin_record_plus_plus'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

     If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 676ms
Running Gradle task 'assembleRelease'...                         1,153ms
Gradle task assembleRelease failed with exit code 1
```